### PR TITLE
Performance improvements.

### DIFF
--- a/og_subgroups.common.inc
+++ b/og_subgroups.common.inc
@@ -569,14 +569,14 @@ function _og_subgroup_user_all_groups($account = NULL, $inheriented_only = TRUE)
   }
 
   if ($inheriented_only) {
-    return $inherited;
+    return array_keys(array_flip($inherited));
   }
 
   foreach ($inherited as $id) {
     $ids[] = $id;
   }
 
-  return $ids;
+  return array_keys(array_flip($ids));
 }
 
 function _og_subgroup_user_parent_groups($ids) {

--- a/og_subgroups.module
+++ b/og_subgroups.module
@@ -125,7 +125,9 @@ function og_subgroups_node_grants($account, $op) {
   $groups = og_subgroup_user_groups_load($account);
   if (!empty($groups)) {
     foreach ($groups as $group_type => $gids) {
-      $grants[OG_ACCESS_REALM . ':' . $group_type] = $gids;
+      if (!empty($gids)) {
+        $grants[OG_ACCESS_REALM . ':' . $group_type][] = $gids;
+      }
     }
   }
   return $grants;


### PR DESCRIPTION
- Queries involving node access have duplicate grant ids stemming from _og_subgroup_user_all_groups not accounting for groups being inherited through multiple group memberships. Perhaps this can be done more intelligently instead of generating all these to then reduce them again?
- Access to lots of groups results in huge node access queries with many repeating 'OR (realm AND gid)' statements. Instead this will create one OR(realm AND IN(gid, gid, gid)).
